### PR TITLE
Switch to permalink, to prevent failed installs after merging Volta rename

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   from = "/*"
 # FIXME: we should still use a function so this works from browsers too, and redirects to an MSI for Windows
 #  to = "https://netlify-functions.notionjs.com/.netlify/functions/get?route=:splat"
-  to = "https://raw.githubusercontent.com/notion-cli/notion/master/dev/unix/boot-install.sh"
+  to = "https://raw.githubusercontent.com/notion-cli/notion/62f247610b8b1b9b21cdd4700190166e21cdd3e9/dev/unix/boot-install.sh"
   status = 302


### PR DESCRIPTION
The Volta rename PR https://github.com/notion-cli/notion/pull/408 makes changes to the `boot-install.sh` script, which is used by `get.notionjs.com`. Updating the configuration to use a permanent link to the current `0.4.1` version of that file, so that Notion installs don't fail in the interim period.